### PR TITLE
index claims by unix seconds

### DIFF
--- a/pkg/format/storageformat/storageformat.go
+++ b/pkg/format/storageformat/storageformat.go
@@ -29,15 +29,6 @@ const (
 	//
 	PostComment = "post/kind/comment/parent/%s"
 
-	// PostCreated is used to store all claim IDs as they have been created in
-	// chronological order.
-	//
-	//     symbol key            claim IDs
-	//                     ->
-	//     post/created          3456,5678
-	//
-	PostCreated = "post/created"
-
 	// PostExpiry is used to store all claim IDs by claim expiry as defined in the
 	// created claim objects. This key helps us to automatically progress in claim
 	// trees, for creating claims of kind "resolve" once a claim of kind "propose"

--- a/pkg/object/objectlabel/lifecycle.go
+++ b/pkg/object/objectlabel/lifecycle.go
@@ -10,6 +10,7 @@ const (
 )
 
 const (
+	LifecycleCreated DesiredLifecycle = "created"
 	LifecycleBalance DesiredLifecycle = "balance"
 	LifecycleDispute DesiredLifecycle = "dispute"
 	LifecyclePropose DesiredLifecycle = "propose"

--- a/pkg/server/serverhandler/posthandler/search.go
+++ b/pkg/server/serverhandler/posthandler/search.go
@@ -135,7 +135,7 @@ func (h *Handler) Search(ctx context.Context, req *post.SearchI) (*post.SearchO,
 	//
 
 	if tim && len(pag) == 2 {
-		lis, err := h.sto.Post().SearchPage(pag[0], pag[1])
+		lis, err := h.sto.Post().SearchPage(objectlabel.LifecycleCreated, pag[0], pag[1])
 		if err != nil {
 			return nil, tracer.Mask(err)
 		}

--- a/pkg/storage/poststorage/interface.go
+++ b/pkg/storage/poststorage/interface.go
@@ -45,15 +45,17 @@ type Interface interface {
 	// reversed order of claim creation time. Given the indexed posts [A B C D E],
 	// the first page [0 3] returns the most recent posts [C D E].
 	//
-	//     @inp[0] the start paging pointer defining the beginning of the page
-	//     @inp[1] the stop paging pointer defining the end of the page
+	//     @inp[0] the lifecycle phase to search for
+	//     @inp[1] the start paging pointer defining the beginning of the page
+	//     @inp[2] the stop paging pointer defining the end of the page
 	//     @out[0] the list of post objects within the given pagination range
 	//
-	SearchPage(int, int) ([]*Object, error)
+	SearchPage(objectlabel.DesiredLifecycle, int, int) ([]*Object, error)
 
 	// SearchExpiry returns the lifecycle specific post objects recorded to have
 	// expired already at the time of execution.
 	//
+	//     @inp[0] the lifecycle phase to search for
 	//     @out[0] the list of post objects already expired
 	//
 	SearchExpiry(objectlabel.DesiredLifecycle) ([]*Object, error)

--- a/pkg/storage/poststorage/redigo_create.go
+++ b/pkg/storage/poststorage/redigo_create.go
@@ -3,7 +3,6 @@ package poststorage
 import (
 	"time"
 
-	"github.com/uvio-network/apiserver/pkg/format/storageformat"
 	"github.com/uvio-network/apiserver/pkg/object/objectlabel"
 	"github.com/xh3b4sd/tracer"
 )
@@ -105,14 +104,14 @@ func (r *Redigo) CreatePost(inp []*Object) error {
 			// Store every claim ID in a global sorted set, based on their time of
 			// creation. This step ensures we can search for claims using pagination
 			// in reverse chronolical order.
-			err = r.red.Sorted().Create().Score(storageformat.PostCreated, inp[i].ID.String(), float64(inp[i].Created.Unix()))
+			err = r.red.Sorted().Create().Score(posLif(objectlabel.LifecycleCreated), inp[i].ID.String(), float64(inp[i].Created.Unix()))
 			if err != nil {
 				return tracer.Mask(err)
 			}
 
 			// We index all claim IDs per specified lifecycle phase, so that we can
 			// search e.g. for all disputes.
-			err = r.red.Sorted().Create().Score(posLif(inp[i].Lifecycle.Data), inp[i].ID.String(), inp[i].ID.Float())
+			err = r.red.Sorted().Create().Score(posLif(inp[i].Lifecycle.Data), inp[i].ID.String(), float64(inp[i].Created.Unix()))
 			if err != nil {
 				return tracer.Mask(err)
 			}

--- a/pkg/storage/poststorage/redigo_delete.go
+++ b/pkg/storage/poststorage/redigo_delete.go
@@ -1,7 +1,7 @@
 package poststorage
 
 import (
-	"github.com/uvio-network/apiserver/pkg/format/storageformat"
+	"github.com/uvio-network/apiserver/pkg/object/objectlabel"
 	"github.com/xh3b4sd/tracer"
 )
 
@@ -37,12 +37,12 @@ func (r *Redigo) DeletePost(inp []*Object) error {
 		}
 
 		if inp[i].Kind == "claim" {
-			err = r.red.Sorted().Delete().Value(storageformat.PostCreated, inp[i].ID.String())
+			err = r.red.Sorted().Delete().Value(posLif(objectlabel.LifecycleCreated), inp[i].ID.String())
 			if err != nil {
 				return tracer.Mask(err)
 			}
 
-			err = r.red.Sorted().Delete().Score(posLif(inp[i].Lifecycle.Data), inp[i].ID.Float())
+			err = r.red.Sorted().Delete().Value(posLif(inp[i].Lifecycle.Data), inp[i].ID.String())
 			if err != nil {
 				return tracer.Mask(err)
 			}

--- a/pkg/storage/poststorage/redigo_search.go
+++ b/pkg/storage/poststorage/redigo_search.go
@@ -242,14 +242,14 @@ func (r *Redigo) SearchOwnerComment(own []objectid.ID, cla []objectid.ID) ([]*Ob
 	return out, nil
 }
 
-func (r *Redigo) SearchPage(beg int, end int) ([]*Object, error) {
+func (r *Redigo) SearchPage(lif objectlabel.DesiredLifecycle, beg int, end int) ([]*Object, error) {
 	var err error
 
 	// val will result in a list of all post IDs within the given pagination
 	// range, if any.
 	var val []string
 	{
-		val, err = r.red.Sorted().Search().Order(storageformat.PostCreated, -(end + 1), -(beg + 1))
+		val, err = r.red.Sorted().Search().Order(posLif(lif), -(end + 1), -(beg + 1))
 		if err != nil {
 			return nil, tracer.Mask(err)
 		}

--- a/pkg/worker/workerhandler/claimcleanuphandler/intern_ensure.go
+++ b/pkg/worker/workerhandler/claimcleanuphandler/intern_ensure.go
@@ -31,10 +31,10 @@ func (h *InternHandler) Ensure(tas *task.Task) error {
 		wee = now.Add(-oneWeek)
 	}
 
-	// Look for all claims of lifecycle phase propose using microsecond scores. We
-	// have to use microseconds because the underlying claims are indexed using
-	// their IDs as scores, where those IDs are in randomized microsecond format
-	// based on claim creation time.
+	// Look for all claims of lifecycle phase created using unix seconds. We want
+	// to ignore all claims that are pending within their first 24 hours of
+	// existance. After that we assumme that those claims should be cleaned up for
+	// good.
 	//
 	//             |       cleanup      | ignore |
 	//     --------x--------------------x--------x----
@@ -42,7 +42,7 @@ func (h *InternHandler) Ensure(tas *task.Task) error {
 	//
 	var pos poststorage.Slicer
 	{
-		pos, err = h.sto.Post().SearchTime(objectlabel.LifecyclePropose, wee.UnixMicro(), day.UnixMicro())
+		pos, err = h.sto.Post().SearchTime(objectlabel.LifecycleCreated, wee.Unix(), day.Unix())
 		if err != nil {
 			return tracer.Mask(err)
 		}


### PR DESCRIPTION
We do this for the ability to paginate search queries by number of objects or by time range. This needs some manual fixing in the existing data on testnet, which is tracked in https://github.com/uvio-network/issues/issues/26. 